### PR TITLE
Added install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@ Cellscope Developer Documentation
 
 Welcome to the developer documentation for Biomage Cellscope.
 
+
+Getting Started
+---------------
+
+If you are on MacOS you can install all the dependencies running (only minor changes are needed for Linux):
+
+    install.sh
+
+The script will also clone the required repositories to run Biomage Cellscope. Go to `api/README.md` for detailed instructions on how to set up and run the platform.
+
+
 Popular questions
 -----------------
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# This scripts install the dependencies needed to run Cellscope by Biomage and clones the repositories.
+
+
+# log outputs the provided string with a timestamp
+log() {
+	d=$(date "+%Y-%m-%d %H:%M:%S")
+	printf "$d $1$2$3"
+}
+
+# color variables.
+red="\033[31m"
+green="\033[32m"
+yellow="\033[33m"
+blue="\033[34m"
+reset="\033[0;m"
+
+
+# Install docker
+log "checking for docker:"
+command -v docker > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+	printf "$green ok$reset\n"
+else
+	printf "$red not found, please install:$reset\n"
+	log "\tcurl -o ~/Downloads/Docker.dmg https://download.docker.com/mac/stable/Docker.dmg && open ~/Downloads/Docker.dmg\n"
+	log "\n"
+	exit 1
+fi
+
+# Install Git
+log "checking for git:"
+command -v git > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+	printf "$green exists$reset\n"
+else
+	printf " does not exist, installing"
+	brew install git > /dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		printf "$green ok$reset\n"
+	else
+		printf "$red failed with code $?$reset\n"
+		exit 1
+	fi
+fi
+
+# Install NPM.
+log "checking for NPM:"
+command -v "npm" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+	printf "$green exists$reset\n"
+else
+	printf " does not exist, installing"
+	brew install npm > /dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		printf "$green ok$reset\n"
+	else
+		printf "$red failed with code $?$reset\n"
+		exit 1
+	fi
+fi
+
+
+# Install and configure aws-cli
+log "checking for aws-cli:"
+command -v "aws" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+	printf "$green exists$reset\n"
+else
+	printf " does not exist, installing"
+	curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+	sudo installer -pkg AWSCLIV2.pkg -target /
+	if [ $? -eq 0 ]; then
+		printf "$green ok$reset\n"
+	else
+		printf "$red failed with code $?$reset\n"
+		exit 1
+	fi
+fi
+
+log "configuring aws-cli \n"
+
+log "-------------------\n"
+log "before running:\n"
+log "make sure that you have an AWS console account, you will need you access key & secret access key\n"
+log "if you don't have an aws account, you can use the mock credentials from aws set-up tutorial provided below"
+log "when prompted set the following field values:\n"
+log " * access key id: AKIAIOSFODNN7EXAMPLE\n"
+log " * secret access key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"
+log " * region: eu-west-1\n"
+log " * output format is: json\n"
+log "press enter to continue\n"
+log "-------------------\n"
+read ok
+
+# Configure aws-cli
+aws configure
+if [ $? -eq 0 ]; then
+	printf "$green ok$reset\n"
+else
+	printf "$red failed with code $?$reset\n"
+	exit 1
+fi
+
+# Clone biomage repositories
+DEFAULT_BIOMAGE_HOME=${HOME}/github.com/biomage-ltd/
+BASE_REPO_URL="https://github.com/biomage-ltd"
+
+printf "Enter desired path for biomage repositories [default: ${DEFAULT_BIOMAGE_HOME}]:\n"
+read biomage_home
+
+if [ "${biomage_home}" == "" ]; then
+	biomage_home=${DEFAULT_BIOMAGE_HOME}
+fi
+
+mkdir -p ${biomage_home}
+prev=$(pwd)
+cd ${biomage_home}
+
+printf "Cloning repositories into: %"
+for repo in iac ui api developer-docs worker data-ingest pipeline inframock biomage-utils; do
+ 	git clone "${BASE_REPO_URL}/${repo}" "${biomage_home}/${repo}"
+done
+
+cd ${prev}


### PR DESCRIPTION
POL - I added the script I used to install all the dependencies needed to run cellscope & clone the required repos. Should be useful for onboardings or contributors.

It can be placed in another place and with another format. For OSS, I'd normally expect a Makefile.

Original PR: https://github.com/hms-dbmi-cellenics/developer-docs/pull/2